### PR TITLE
Updates for Windows Server deployment on GCP Compute Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,22 @@ Set-ExecutionPolicy Unrestricted
 ```
 
 # Usage within GCP Compute Engine
-When manually creating a new Compute Engine instance, expand "Management, security, disks, networking, sole tenance" and Copy/Paste the following into the 'Startup script' textarea.
+## Linux-based instances
+When manually creating a new Compute Engine instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy") and then expand the Management subsection.  Copy/Paste the following into the Automation 'Startup script' textarea.
 Be sure to replace the S1_CONSOLE_PREFIX (ie: usea1-011), API_KEY, SITE_TOKEN and VERSION_STATUS (ie: GA or EA) values with appropriate values:
 ```
 #!/bin/bash
 sudo curl -L "https://raw.githubusercontent.com/s1-howie/s1-agents-helper/master/s1-agent-helper.sh" -o s1-agent-helper.sh
 sudo chmod +x s1-agent-helper.sh
 sudo ./s1-agent-helper.sh S1_CONSOLE_PREFIX API_KEY SITE_TOKEN VERSION_STATUS
+```
+## Windows-based instances
+When manually creating a new Compute Engine Windows Server instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy") and then expand the Management subsection.  Create new Metadata with "Key 1" set to `sysprep-specialize-script-ps1` and Copy/Paste the following into the "Value 1" textarea.
+Be sure to replace the S1_CONSOLE_PREFIX (ie: usea1-011), API_KEY, SITE_TOKEN and VERSION_STATUS (ie: GA or EA) values with appropriate values:
+```
+Set-ExecutionPolicy Unrestricted -Force
+(new-object Net.WebClient).DownloadFile("https://raw.githubusercontent.com/s1-howie/s1-agents-helper/master/s1-agent-helper.ps1", "$env:TEMP\s1-agent-helper.ps1")
+& "$env:TEMP\s1-agent-helper.ps1" S1_CONSOLE_PREFIX API_KEY SITE_TOKEN VERSION_STATUS
 ```
 
 # Usage within Azure Virtual Machines

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Set-ExecutionPolicy Unrestricted
 
 # Usage within GCP Compute Engine
 ## Linux-based instances
-When manually creating a new Compute Engine instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy") and then expand the Management subsection.  Copy/Paste the following into the Automation 'Startup script' textarea.
+When manually creating a new Compute Engine instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy)" and then expand the Management subsection.  Copy/Paste the following into the Automation 'Startup script' textarea.
+
 Be sure to replace the S1_CONSOLE_PREFIX (ie: usea1-011), API_KEY, SITE_TOKEN and VERSION_STATUS (ie: GA or EA) values with appropriate values:
 ```
 #!/bin/bash
@@ -53,7 +54,10 @@ sudo chmod +x s1-agent-helper.sh
 sudo ./s1-agent-helper.sh S1_CONSOLE_PREFIX API_KEY SITE_TOKEN VERSION_STATUS
 ```
 ## Windows-based instances
-When manually creating a new Compute Engine Windows Server instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy") and then expand the Management subsection.  Create new Metadata with "Key 1" set to `sysprep-specialize-script-ps1` and Copy/Paste the following into the "Value 1" textarea.
+When manually creating a new Compute Engine Windows Server instance, expand "Advanced Options (Networking, disks, security, management, sole-tenancy)" and then expand the Management subsection.  
+
+Create new Metadata with "Key 1" set to `sysprep-specialize-script-ps1` and Copy/Paste the following into the "Value 1" textarea.
+
 Be sure to replace the S1_CONSOLE_PREFIX (ie: usea1-011), API_KEY, SITE_TOKEN and VERSION_STATUS (ie: GA or EA) values with appropriate values:
 ```
 Set-ExecutionPolicy Unrestricted -Force

--- a/s1-agent-helper.ps1
+++ b/s1-agent-helper.ps1
@@ -95,7 +95,7 @@ $wc.DownloadFile($agent_download_link, "$env:TEMP\$agent_file_name")
 
 # If the agent package is version 22.1+, use the new CLI installation syntax
 if ($agent_package_major_version -ge "22.1") {
-    & "$env:TEMP\$agent_file_name" -t $site_token
+    & "$env:TEMP\$agent_file_name" -t $site_token -q
 }
 else {
     #Execute the older EXE package


### PR DESCRIPTION
This change addresses the issues from this screenshot.

Without the `-q` flag, the 22.x installer will launch a GUI.

Adding `-Force` to the PowerShell configuration also eliminates the CLI prompt.

![gcp_windows_installer_not_quiet](https://user-images.githubusercontent.com/108744621/205746814-6f6fea01-11f2-40e7-80a0-ab244c5cdb69.png)
